### PR TITLE
Removed all mention of meta-buildpack

### DIFF
--- a/buildpacks.html.md.erb
+++ b/buildpacks.html.md.erb
@@ -27,9 +27,13 @@ Buildpacks compile and package apps to run on PCF. This topic lists resources fo
 
 ## <a id="other"></a> Other Buildpacks
 
-- [Meta-Buildpack](https://github.com/guidowb/meta-buildpack)
+Buildpacks can also be used to inject additional code into the application container:
 
-- [Spring Config Decorator Buildpack](https://github.com/guidowb/spring-config-decorator)
+- [Agent Injection with a supply buildpack](https://docs.pivotal.io/pivotalcf/buildpacks/custom.html)
+
+- [Eureka Registrar Sidecar](https://github.com/cf-platform-eng/eureka-registrar-sidecar)
+
+- [Spring Config Injection](https://github.com/cf-platform-eng/spring-config-injection)
 
 ## <a id="custom"></a> Custom Buildpacks
 

--- a/cf-concepts.html.md.erb
+++ b/cf-concepts.html.md.erb
@@ -40,19 +40,19 @@ Most value-add integrations are done by exposing your software to customer appli
 
 ## <a id="buildpacks"></a> Buildpacks
 
-When application code is deployed to Cloud Foundry, it is processed by a language-specific buildpack. Language buildpacks provide a convenient integration hook for any service that needs to inspect or embellish application code. The meta-buildpack also provides a language-agnostic way to inject your code into the application container image.
+When application code is deployed to Cloud Foundry, it is processed by a language-specific buildpack. Language buildpacks provide a convenient integration hook for any service that needs to inspect or embellish application code. Supply buildpacks also provide a language-agnostic way to inject your code into the application container image.
 
 - [Application Staging Process](http://docs.pivotal.io/pivotalcf/concepts/how-applications-are-staged.html) explains how PCF packages and deploys apps in containers with buildpacks so that they can run on multiple VMs interchangeably.
 - [Language Buildpacks](http://docs.pivotal.io/pivotalcf/buildpacks/index.html) describes the language-specific buildpacks support PCF apps.
-- [Meta Buildpack](https://github.com/guidowb/meta-buildpack) describes how to use "decorator" buildpacks to lessen the buildpack overhead needed for apps written in multiple languages.
+- [Custom Buildpacks](https://docs.pivotal.io/pivotalcf/buildpacks/custom.html) describes how to use supply buildpacks to add dependencies or code without having to change (multiple) language-sepcific buildpacks.
 
 ## <a id="agents"></a> Embedded Agents
 
 Some integrations depend on the ability to inject code into the application container.
 We refer to these injected components as "container-embedded agents".
-[Buildpacks](#buildpacks) provide a mechanism to inject components into the application container image, and the `.profile.d` directory provides a way to start agents before or alongside the customer application.
+[Buildpacks](./buildpacks.html#other) provide a mechanism to inject components into the application container image, and the `.profile.d` directory provides a way to start agents before or alongside the customer application.
 
-- [Agent Injection with the meta-buildpack](https://github.com/guidowb/meta-buildpack)
+- [Agent Injection with a supply buildpack](https://docs.pivotal.io/pivotalcf/buildpacks/custom.html)
 - [Using .profile.d](http://docs.pivotal.io/pivotalcf/devguide/deploy-apps/deploy-app.html#profile)
 
 

--- a/embedded-agents.html.md.erb
+++ b/embedded-agents.html.md.erb
@@ -17,10 +17,7 @@ Some service integrations depend on the ability to inject code into application 
 
 We refer to these injected components as "container-embedded agents."
 
-[Buildpacks](buildpacks.html) provide a mechanism to inject components into the application container image, and the `.profile.d` directory provides a way to start agents before or alongside the customer application.
-
 ## <a id="resources"></a> Embedded Agents Resources
 
-- [Agent Injection with the Meta-Buildpack](https://github.com/guidowb/meta-buildpack)
-
+- [Buildpacks](./buildpacks.html#other) provide a mechanism to inject components into the application container image, and the `.profile.d` directory provides a way to start agents before or alongside the customer application.
 - [Using .profile.d](http://docs.pivotal.io/pivotalcf/devguide/deploy-apps/deploy-app.html#profiled)

--- a/tile-generator.html.md.erb
+++ b/tile-generator.html.md.erb
@@ -865,27 +865,28 @@ stemcell_criteria:
 
 Tile Generator supplies standard errands to deploy and delete CF type packages. You can
 replace or augment those errands by specifying errand shell commands in your tile.yml
-file. For example:
+file. Here is an example of a custom deploy errand to install a buildpack only is a newer
+version of that same buildpack is not already present:
 
 ```
 packages:
-- name: meta-buildpack
+- name: my-buildpack
   type: buildpack
   buildpack_order: 0 # Go to head of list
-  path: meta_buildpack.zip
+  path: my_buildpack.zip
   deploy: |
-    cp meta_buildpack.zip meta_buildpack-v{{context.version}}.zip
-    existing=`cf buildpacks | grep '^meta_buildpack'`
+    cp my_buildpack.zip my_buildpack-v{{context.version}}.zip
+    existing=`cf buildpacks | grep '^my_buildpack'`
     if [ -z "$existing" ]; then
-      cf create-buildpack meta_buildpack meta_buildpack-v{{context.version}}.zip 0
+      cf create-buildpack my_buildpack my_buildpack-v{{context.version}}.zip 0
     else
-      semver=`echo "$existing" | sed 's/.* meta_buildpack-v\(.*\)\.zip/\1/'`
+      semver=`echo "$existing" | sed 's/.* my_buildpack-v\(.*\)\.zip/\1/'`
       if is_newer "{{context.version}}" "$semver"; then
-        cf update-buildpack meta_buildpack -p meta_buildpack-v{{context.version}}.zip
+        cf update-buildpack my_buildpack -p my_buildpack-v{{context.version}}.zip
       else
-        echo "Newer version ($semver) of meta_buildpack is already present"
+        echo "Newer version ($semver) of my_buildpack is already present"
       fi
-      cf update-buildpack meta_buildpack -i 0
+      cf update-buildpack my_buildpack -i 0
     fi
   delete: |
     # Intentional no-op, as others may have a dependency on this


### PR DESCRIPTION
Meta-buildpack and decorators are being deprecated and have been
supplanted by the native supply buildpack capabilities. Tile
developers should no longer be using meta-buildpack.

This change should be made to the documentation for **all** PCF versions.