### PR TITLE
Fix `zero_if` property name

### DIFF
--- a/product-template-reference.html.md.erb
+++ b/product-template-reference.html.md.erb
@@ -560,7 +560,7 @@ job_types:
         max: 1
       zero_if:
         property_reference: '.web_server.example_text'
-        property_value: 'magic value'
+        property_values: ['magic value']
     resource_definitions:
       - name: ram
         type: integer


### PR DESCRIPTION
zero_if has a property called `property_values`, not `property_value` and the value of it should be an array, not a string.

For reference, here's the spec file which defines that:
https://github.com/pivotal-cf/installation/blob/92a965dd10005e42a0aa451eddb58ac66418dedb/web/spec/models/persistence/metadata/zero_if_binding_spec.rb#L31