### PR TITLE
Update docs to include required properties

### DIFF
--- a/product-template-reference.html.md.erb
+++ b/product-template-reference.html.md.erb
@@ -67,7 +67,7 @@ The version number is important for [migrations](./tile-upgrades.html).
 
 ### <a id='top-min-version'></a> minimum\_version\_for\_upgrade
 
-String. Optional. Pivotal recommends that you set a minimum version for upgrading to your current product version.
+String. Required. Pivotal requires that you set a minimum version for upgrading to your current product version.
 This example shows a current product version of v1.7 that only upgrades from a v1.6.x version of the same product:
 
 <pre>
@@ -157,6 +157,8 @@ Array of Hashes. Required.
 The list of releases contained in your product's releases directory.
 The version of the release must be exactly the same as the version contained in the release (BOSH releases are versioned and signed by BOSH).
 
+Each release requires the following keys: name, file, version.
+
 ### <a id='top-post-deploy'></a> post\_deploy\_errands
 
 Array of Hashes. Optional.
@@ -165,13 +167,10 @@ A list of errands that run after a deploy succeeds.
 Set the `run_post_deploy_errand_default:` property to `on` or `off` to set the default for the errand's run rule selector in Ops Manager.
 See [Lifecycle Errands](./tile-errands.html). If this property is not supplied, the selector defaults to `On`.
 
-### <a id='top-pre-delete'></a> pre\_delete\_errands
+### <a id='top-icon-image'></a> icon\_image
+Base64 Image. Required.
 
-Array of Hashes. Optional.
-A list of errands that run before a deployment is deleted.
-
-Set the `run_pre_delete_errand_default:` property to `on` or `off` to set the default for the errand's run rule selector in Ops Manager.
-See [Lifecycle Errands](./tile-errands.html). If this property is not supplied, the selector defaults to `On`.
+This is the icon that will display on the tile in the the Ops Manager Installation Dashboard.
 
 ## <a id='form-properties'></a> Form Properties
 


### PR DESCRIPTION
- `minimum_version_for_upgrade` is not optional
- document `icon_image`, which is a required top level property
- document the required keys needed for each release

This was discovered on Ops Manager 2.2 but probably applies to the docs for the other versions as well.

@pivotal-cf/pcf-ops-manager I'm not positive of what is acceptable values for the `icon_image` and if it's only base64 encoded..

![](https://user-images.githubusercontent.com/7475663/45909680-21975c80-bdb8-11e8-8cb2-c103e3043070.png)