### PR TITLE
Add documentation for instance_types_catalog accessor to $ops_manager…

### DIFF
--- a/property-template-references.html.md.erb
+++ b/property-template-references.html.md.erb
@@ -167,6 +167,9 @@ Outside of properties, you can also retrieve information about various configura
   </tr><tr>
   <td>no_proxy</td>
   <td>Provides the CSVs that should not go through a proxy</td></tr>
+  <tr>
+  <td>instance_types_catalog</td>
+  <td>Provides a list of all available VM types. Includes custom VM types.</td></tr>
 </tr>
 </table>
 


### PR DESCRIPTION
See https://www.pivotaltracker.com/story/show/162925888

This is a 2.4+ feature, so there will be a separate pull request created for master/2.5.

[#162925888] Tile authors should be able to get the VM type catalog via a double parens accessor

Thanks!