### PR TITLE
Add documentation for instance_types_catalog accessor to $ops_manager…

### DIFF
--- a/property-template-references.html.md.erb
+++ b/property-template-references.html.md.erb
@@ -167,6 +167,9 @@ Outside of properties, you can also retrieve information about various configura
   </tr><tr>
   <td>no_proxy</td>
   <td>Provides the CSVs that should not go through a proxy</td></tr>
+  <tr>
+  <td>instance_types_catalog</td>
+  <td>Provides a list of all available VM types. Includes custom VM types.</td></tr>
 </tr>
 </table>
 


### PR DESCRIPTION
See https://www.pivotaltracker.com/story/show/162671477

This is the corresponding 2.5 PR for https://github.com/pivotal-cf/docs-tiledev/pull/47

[#162671477] Tile authors should be able to get the VM type catalog via a double parens accessor

Thanks!