### PR TITLE
Add documention for new syslog field in migration

### DIFF
--- a/migrating-syslog-configuration.html.md.erb
+++ b/migrating-syslog-configuration.html.md.erb
@@ -84,6 +84,12 @@ By enabling the Ops Manager syslog feature, Ops Manager:
     <td>No</td>
     <td>Defaults to <code>false</code></td>
   </tr>
+  <tr>
+    <td><code>custom_rsyslog_configuration</code></td>
+    <td>text</td>
+    <td>No</td>
+    <td>Additional configuration for rsyslog written in the rainerscript syntax. For example, 'if ($app-name startswith "exampleComponent") then stop' can be used to drop all traffic from a particular component. Entered configuration will be applied prior to the forwarding rule.</td>
+  </tr>
 </table>
 
 ## <a id="javascript"></a> Use the JavaScript Migration Process


### PR DESCRIPTION
This PR adds a new row in the table of possible fields that can be in a JS migration. This is a 2.5 only feature, so it only needs to be merged into the master branch.

[#163010171] Update tile dev docs for new advanced properties

Signed-off-by: Ryan Moran <rmoran@pivotal.io>