### PR TITLE
Add missing documentation for Product Context

### DIFF
--- a/property-template-references.html.md.erb
+++ b/property-template-references.html.md.erb
@@ -141,6 +141,31 @@ Ops Manager allows empty arrays in double-parentheses expressions. For example:
 
 For more information about the available properties and their accessors, see the [Property Blueprint Reference](#property-blueprints).
 
+### <a id='product'></a>Product Context
+
+Product context is useful to access information about a product. It can be used in a manifest using this syntax:
+
+```
+  (( ..PRODUCT-NAME.accessor ))
+```
+
+These are the list of allowed accessors:
+
+<table class="nice">
+  <tr>
+    <th>Accessor name</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>deployment_name</td>
+    <td>Provides the deployment name passed to BOSH for the product</td>
+  </tr>
+  <tr>
+    <td>network_name</td>
+    <td>Provides the name of the network assigned for the product</td>
+  </tr>
+</table>
+
 ### <a id='dollar'></a>Dollar Contexts
 
 Outside of properties, you can also retrieve information about various configuration details of your product and Ops Manager.


### PR DESCRIPTION
In 2.1, we had a list of global accessors that a tile author could use. This included dollar context accessors and dot context accessors. See https://docs.pivotal.io/tiledev/2-1/product-template-reference.html#ops-man-snippets.

In the 2.4 documentation (https://docs.pivotal.io/tiledev/2-4/property-template-references.html), we seem to have lost the documentation of the dot-dot context.

[#163910695] Add tile dev documentation for dot-dot context

Signed-off-by: Shaan Sapra <shsapra@pivotal.io>