### PR TITLE
[DO NOT MERGE YET] Document new constraint on secret property

### DIFF
--- a/tile-reference/property-blueprints/_secret.html.erb
+++ b/tile-reference/property-blueprints/_secret.html.erb
@@ -6,8 +6,18 @@
     allows_default_to_be_specified: false,
     value_accessor_description: 'Returns the secret as a string or null.',
     value_present_accessor_description: 'Returns true if value is a non-empty string.',
-    additional_property_blueprint_attributes: [],
-    
+    additional_property_blueprint_attributes: [
+      {
+        name: 'constraints.must_match_regex',
+        description: <<~DESC
+          A regular expression that the user input must match. Create a validator that runs on the form save event.
+          If the user input does not match the <code>must_match_regex</code> constraint, the form displays the specified <code>error_message</code>.
+          Multiple <code>must_match_regex</code> constraints for a single property blueprint are evaluated in the order listed.
+          See the example below for example on how to use.
+          DESC
+      }
+    ],
+
     additional_accessors: [],
     examples: [
       {
@@ -21,6 +31,9 @@
             - name: example_secret
               type: secret
               configurable: true
+              constraints:
+                - must_match_regex: '^[a-zA-Z]{20,}$'
+                  error_message: 'This password must be at least 20 letters'
 
           form_types:
             - name: example_secret


### PR DESCRIPTION
[#159629595] Operator should not be able to set a secret that does not match the required regex.

Story: https://www.pivotaltracker.com/story/show/159629595

When we release the OpsManager patch that allows this feature, we should merge this PR and make this documentation public. We should also merge this forward for 2.4, 2.5 and beyond