### PR TITLE
Update tile-generator.html.md.erb

### DIFF
--- a/tile-generator.html.md.erb
+++ b/tile-generator.html.md.erb
@@ -584,10 +584,10 @@ forms:
   - name: country
     type: dropdown_select
     label: Country
+    default: country_us
     options:
     - name: country_us
       label: US
-      default: true
     - name: country_elsewhere
       label: Elsewhere
 - name: account-info-1


### PR DESCRIPTION
According to https://docs.pivotal.io/tiledev/2-4/property-template-references.html, `dropdown_select` option default should be configured using `default` value on the property itself.