### PR TITLE
Update tile-generator.html.md.erb

### DIFF
--- a/tile-generator.html.md.erb
+++ b/tile-generator.html.md.erb
@@ -491,6 +491,7 @@ by using the `docker-bosh` type:
 
 If a Docker image cannot be downloaded by BOSH dynamically, provide a ready-made Docker image
 and package it as part of the BOSH release. In that case, specify the image as a local file.
+This file must be a `.tgz`.
 
 ```
 - name: docker-bosh2


### PR DESCRIPTION
Add explicit note that the docker image must be a .tgz (without this hint, folks might try to use a .tar)