### PR TITLE
[2.1] Remove references to ERT

### DIFF
--- a/environments.html.md.erb
+++ b/environments.html.md.erb
@@ -11,7 +11,7 @@ This topic explains how to set up tile development environments, from simple sta
 
 Pivotal provides a lightweight (vagrant packaged) instance of PCF with some
 basic services as a free product named PCF Dev. This is a great environment
-to develop and test everything that runs in the Cloud Foundry Elastic Runtime.
+to develop and test everything that runs in PAS.
 
 Either of these environments allow you to develop the first three levels of service for Pivotal Cloud Foundry (PCF): a [User-Provided Service](./user-provided.html), a [Brokered Service](./brokered.html), and a [Managed Service](./managed.html).
 

--- a/pcf-command.html.md.erb
+++ b/pcf-command.html.md.erb
@@ -135,7 +135,7 @@ $ pcf install test-tile 0.0.2
 
 Where you would normally configure the tile settings in the GUI, the `configure`
 command lets you pass in any user-specified properties as a .yml file. This command
-also sets the stemcell for the tile to the same one used by your Elastic Runtime,
+also sets the stemcell for the tile to the same one used by your PAS,
 to avoid the need to upload a tile-specific stemcell.
 
 ```bash
@@ -217,9 +217,9 @@ up Ops Manager's available products (and disk space):
 $ pcf delete-unused-products
 ```
 
-##<a id="access-ert"></a> Accessing Elastic Runtime
+##<a id="access-ert"></a> Accessing PAS
 
-To see details about the Elastic Runtime of your PCF environment:
+To see details about the PAS of your PCF environment:
 
 ```bash
 $ pcf cf-info

--- a/product-template-reference.html.md.erb
+++ b/product-template-reference.html.md.erb
@@ -929,9 +929,9 @@ users cannot edit this value and the <strong>Resource Config</strong> page in <s
 Hash. Required.
 The number of default instances for a job along with max, min, odd, and the ability to decrease sizing after deploy constraints.
 
-If your product uses an external service that performs the same job as a service in Elastic Runtime,
+If your product uses an external service that performs the same job as a service in PAS,
 you can reduce resource usage by setting the instance count of a job to `0` with the `zero_if` property.
-For example, your product uses Amazon Relational Database Service (RDS) instead of MySQL, which is the default system database for Elastic Runtime.
+For example, your product uses Amazon Relational Database Service (RDS) instead of MySQL, which is the default system database for PAS.
 Set `property reference` to `.properties.system.database` and `property value` to `magic value` to change the instance counts of all MySQL jobs to `0`.
 
 ### <a id='job-manifest'></a> manifest

--- a/tile-documentation.html.md.erb
+++ b/tile-documentation.html.md.erb
@@ -55,10 +55,10 @@ If a trial license available, customers interested in using Partner can obtain a
 Current Partner Tile for Pivotal Cloud Foundry Details:
 
 - Version:
-- Release Date: 
+- Release Date:
 - Software components versions: Partner product version
-- Compatible Ops Manager Version(s): 1.5.x, 1.6.x
-- Compatible Elastic Runtime Version(s): 1.4.x, 1.5.x, 1.6.x
+- Compatible Ops Manager Version(s): 2.0.x, 2.1.x
+- Compatible PAS Version(s): 2.0.x, 2.1.x
 
 #### <a id='requirements'></a> Requirements (or Prerequisites, Packaging Dependencies for Offline Buildpacks, etc.)
 

--- a/tile-errands.html.md.erb
+++ b/tile-errands.html.md.erb
@@ -166,9 +166,9 @@ Post-deploy errands run by default. An operator can prevent a post-deploy errand
 
 ![Example Errand](img/example-errand.png)
 
-For example, Redis has a **Broker Registrar** post-deploy errand that the Elastic Runtime tile uses to register its service broker with the Cloud Controller and publish its service plans.
+For example, Redis has a **Broker Registrar** post-deploy errand that the PAS tile uses to register its service broker with the Cloud Controller and publish its service plans.
 
-If an operator chooses **Off** in the drop-down menu for Elastic Runtime's **Broker Registrar** errand before installation, Elastic Runtime's service broker is not registered with the Cloud Controller and its service plans are not made public.
+If an operator chooses **Off** in the drop-down menu for Redis's **Broker Registrar** errand before installation, Redis's service broker is not registered with the Cloud Controller and its service plans are not made public.
 
 ##<a id='pre-delete'></a>Pre-Delete Errands
 

--- a/tile-generator.html.md.erb
+++ b/tile-generator.html.md.erb
@@ -416,7 +416,7 @@ bosh-release package's deployment manifest, you can include the
 
 #### <a id="docker"></a> Docker Images
 
-Apps packages as Docker images can be deployed inside or outside PAS.
+Apps packaged as Docker images can be deployed inside or outside PAS.
 To push a Docker image as a CF app, use the *Pushed Application*
 format specified above, but use the `docker-app` or `docker-app-broker` type instead
 of just `app` or `app-broker`. The Docker image to be used is then specified using

--- a/tile-generator.html.md.erb
+++ b/tile-generator.html.md.erb
@@ -24,7 +24,7 @@ PCF:
 
 - **BOSH errands** to deploy and delete your software, including blue/green
   deployments for zero-downtime upgrades
-- A **BOSH release** suitable for deploying your software to the Elastic Runtime
+- A **BOSH release** suitable for deploying your software to PAS
   or open-source Cloud Foundry
 - A **Pivotal Ops Manager Tile** that can be imported into Ops Manager, installed,
   configured, and deployed, including UI forms and automatic upgrades from
@@ -40,8 +40,8 @@ combination of the following package types:
 
 - Cloud Foundry Applications
 - Cloud Foundry Buildpacks
-- Cloud Foundry Service Brokers (both inside and outside the Elastic Runtime)
-- Docker images (both inside and outside the Elastic Runtime)
+- Cloud Foundry Service Brokers (both inside and outside PAS)
+- Docker images (both inside and outside PAS)
 
 ### <a id="legacy"></a>Legacy Tiles and OSS-Compatible Service Brokers
 
@@ -195,8 +195,7 @@ each package entry depends on the type of package you are adding.
 
 #### <a id="pushed"></a> Pushed Apps
 
-Apps (including service brokers) that are being `cf push`ed into the
-Elastic Runtime use the following format:
+Apps (including service brokers) that are being `cf push`ed into PAS use the following format:
 
 ```yaml
 - name: my-application
@@ -249,7 +248,7 @@ existing service instance, use the `services` property of the `manifest` instead
 
 `needs_cf_credentials` causes the app to receive two additional environment
 variables named `CF_ADMIN_USER` and `CF_ADMIN_PASSWORD` with the admin credentials
-for the Elastic Runtime into which they are being deployed. This allows apps and
+for the PAS into which they are being deployed. This allows apps and
 services to interact with the Cloud Controller.
 
 The `auto_services` feature is described in more detail below.
@@ -264,7 +263,7 @@ environment variables on the app:
 
 #### <a id="brokers"></a> Service Brokers
 
-Most modern service brokers are pushed into the Elastic Runtime as normal
+Most modern service brokers are pushed into PAS as normal
 CF apps. For these types of brokers, use the Pushed Application format
 specified above, but set the type to `app-broker` or `docker-app-broker` instead
 of just `app` or `docker-app`:
@@ -417,8 +416,8 @@ bosh-release package's deployment manifest, you can include the
 
 #### <a id="docker"></a> Docker Images
 
-Apps packages as Docker images can be deployed inside or outside the Elastic
-Runtime. To push a Docker image as a CF app, use the *Pushed Application*
+Apps packages as Docker images can be deployed inside or outside PAS.
+To push a Docker image as a CF app, use the *Pushed Application*
 format specified above, but use the `docker-app` or `docker-app-broker` type instead
 of just `app` or `app-broker`. The Docker image to be used is then specified using
 the `image` property:
@@ -436,7 +435,7 @@ If this app is also a service broker, use `docker-app-broker` instead of just
 delegate their persistence to bound services.
 
 Docker apps that require persistent storage can not be deployed into
-the Elastic Runtime. These can be deployed to separate BOSH-managed VMs instead
+PAS. These can be deployed to separate BOSH-managed VMs instead
 by using the `docker-bosh` type:
 
 ```
@@ -612,8 +611,8 @@ plain text as all other value types.
 ### Automatic Provisioning of Services
 
 Tile Generator automates the provisioning of services. Any app (including
-service brokers and Docker-based apps) that are being pushed into the
-Elastic Runtime can automatically be bound to services through the `auto_services`
+service brokers and Docker-based apps) that are being pushed into PAS
+can automatically be bound to services through the `auto_services`
 feature:
 
 ```
@@ -672,7 +671,7 @@ the requested service.
 ### Orgs and Spaces
 
 By default, Tile Generator creates a single new org and space for any
-packages that install into the Elastic Runtime, using the name of the tile and
+packages that install into PAS, using the name of the tile and
 appending `-org` and `-space`, respectively. The default memory quota for a
 newly created org is 1024 (1&nbsp;G). You can change any of these defaults by
 specifying the following properties in `tile.yml`:

--- a/tile-structure.html.md.erb
+++ b/tile-structure.html.md.erb
@@ -77,7 +77,7 @@ A tile also writes fixed, unconfigurable properties into the BOSH manifest that 
 
 #### <a id='credentials'></a> Credentials
 
-Include credentials to pass into a BOSH manifest as `salted_credentials` in your `tile.yml` file. But you need not include credentials that already exist in other tiles, such as Elastic Runtime. BOSH automatically generates these for any packages that require them.
+Include credentials to pass into a BOSH manifest as `salted_credentials` in your `tile.yml` file. But you need not include credentials that already exist in other tiles, such as PAS. BOSH automatically generates these for any packages that require them.
 
 ### <a id='errands'></a> Errands
 


### PR DESCRIPTION
Remove references to Elastic Runtime.

Includes correction of who the "Broker Registrar" errand belongs to on the tile-errands page.

For https://www.pivotaltracker.com/story/show/163204665