### PR TITLE
Remove references to ERT

### DIFF
--- a/tile-documentation.html.md.erb
+++ b/tile-documentation.html.md.erb
@@ -55,10 +55,10 @@ If a trial license available, customers interested in using Partner can obtain a
 Current Partner Tile for Pivotal Cloud Foundry Details:
 
 - Version:
-- Release Date: 
+- Release Date:
 - Software components versions: Partner product version
-- Compatible Ops Manager Version(s): 1.5.x, 1.6.x
-- Compatible Elastic Runtime Version(s): 1.4.x, 1.5.x, 1.6.x
+- Compatible Ops Manager Version(s): 2.0.x, 2.1.x
+- Compatible PAS Version(s): 2.0.x, 2.1.x
 
 #### <a id='requirements'></a> Requirements (or Prerequisites, Packaging Dependencies for Offline Buildpacks, etc.)
 

--- a/tile-errands.html.md.erb
+++ b/tile-errands.html.md.erb
@@ -141,8 +141,8 @@ Dashboard or on the service's **Settings** tab **Errands** pane, before installi
 For example, Redis has a **Broker Registrar** post-deploy errand that the Pivotal Application Service (PAS)  tile uses
 to register its service broker with the Cloud Controller and publish its service plans.
 
-If an operator selects **Off** in dropdown for PAS **Broker Registrar** errand
-before installation, PAS service broker is not registered with the Cloud Controller and its service plans are not made public.
+If an operator selects **Off** in dropdown for Redis's **Broker Registrar** errand
+before installation, Redis's service broker is not registered with the Cloud Controller and its service plans are not made public.
 
 ##<a id='pre-delete'></a>Pre-Delete Errands
 

--- a/tile-generator.html.md.erb
+++ b/tile-generator.html.md.erb
@@ -41,7 +41,7 @@ combination of the following package types:
 - Cloud Foundry Applications
 - Cloud Foundry Buildpacks
 - Cloud Foundry Service Brokers (both inside and outside PAS)
-- Docker images (both inside and outside PAS )
+- Docker images (both inside and outside PAS)
 
 ### <a id="legacy"></a> Legacy Tiles and OSS-Compatible Service Brokers
 
@@ -262,7 +262,7 @@ existing service instance, use the `services` property of the `manifest` instead
 
 `needs_cf_credentials` causes the app to receive two additional environment
 variables named `CF_ADMIN_USER` and `CF_ADMIN_PASSWORD` with the admin credentials
-for PAS into which they are being deployed. This allows apps and
+for the PAS into which they are being deployed. This allows apps and
 services to interact with the Cloud Controller.
 
 The `auto_services` feature is described in more detail below.
@@ -430,8 +430,8 @@ bosh-release package's deployment manifest, you can include the
 
 #### <a id="docker"></a> Docker Images
 
-Apps packages as Docker images can be deployed inside or outside the Elastic
-Runtime. To push a Docker image as a CF app, use the *Pushed Application*
+Apps packages as Docker images can be deployed inside or outside PAS.
+To push a Docker image as a CF app, use the *Pushed Application*
 format specified above, but use the `docker-app` or `docker-app-broker` type instead
 of just `app` or `app-broker`. The Docker image to be used is then specified using
 the `image` property:

--- a/tile-generator.html.md.erb
+++ b/tile-generator.html.md.erb
@@ -430,7 +430,7 @@ bosh-release package's deployment manifest, you can include the
 
 #### <a id="docker"></a> Docker Images
 
-Apps packages as Docker images can be deployed inside or outside PAS.
+Apps packaged as Docker images can be deployed inside or outside PAS.
 To push a Docker image as a CF app, use the *Pushed Application*
 format specified above, but use the `docker-app` or `docker-app-broker` type instead
 of just `app` or `app-broker`. The Docker image to be used is then specified using


### PR DESCRIPTION
Remove references to Elastic Runtime.

Includes correction of who the "Broker Registrar" errand belongs to on the tile-errands page.

For https://www.pivotaltracker.com/story/show/163204665