### PR TITLE
Fix minor typo

### DIFF
--- a/testing.html.md.erb
+++ b/testing.html.md.erb
@@ -86,7 +86,7 @@ The following are general recommendations for designing and running tests on PCF
 
 * Re-use tests that exist already, for example in Concourse.
 
-* Use an example CF app that uses your service. This app can serve for testing, demoing your tile capabilities, and as a code code example.
+* Use an example CF app that uses your service. This app can serve for testing, demoing your tile capabilities, and as a code example.
   See the [MySQL Test App](https://github.com/cloudfoundry-incubator/cf-mysql-acceptance-tests/tree/master/assets/sinatra_app) an example.
 
 * When testing manually, using the UI is better than calling the underlying API directly.


### PR DESCRIPTION
This fixes a super minor typo, and could be applied to all of your active 2.x branches. 