### PR TITLE
Add documenation for HttpSuccessVerifier

### DIFF
--- a/property-template-references.html.md.erb
+++ b/property-template-references.html.md.erb
@@ -616,7 +616,7 @@ The following table lists the available install-time verifiers:
       Verifies that...
     </th>
     <th width="210px">
-      Required Properties
+      Properties
     </th>
   </tr>
   <tr>
@@ -630,7 +630,8 @@ The following table lists the available install-time verifiers:
         <li><code>access_key_id</code></li>
         <li><code>bucket_name</code></li>
         <li><code>secret_access_key</code></li>
-        <li><code>signature_version</code></li>
+        <li><code>signature_version (optional)</code></li>
+        <li><code>region (optional)</code></li>
       </ul>
     </td>
   </tr>
@@ -661,6 +662,10 @@ The following table lists the available install-time verifiers:
         <li><code>password</code></li>
         <li><code>port</code></li>
         <li><code>username</code></li>
+        <li><code>tls_enabled (optional)</code></li>
+        <li><code>tls_ca (optional)</code></li>
+        <li><code>tls_certificate (optional)</code></li>
+        <li><code>tls_private_key (optional)</code></li>
       </ul>
     </td>
   </tr>
@@ -732,6 +737,24 @@ The following table lists the available install-time verifiers:
         <li><code>vcenter_credentials</code></li>
         <li><code>datacenter</code></li>
         <li><code>datastore_pattern</code></li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>Verifiers::HTTPSuccessVerifier</code>
+    </td>
+    <td>
+      the specified endpoint returns successfully.
+    </td>
+    <td>
+      <ul>
+         <li><code>host</code></li>
+         <li><code>port</code></li>
+         <li><code>path</code></li>
+         <li><code>scheme</code></li>
+         <li><code>must_match_regex (optional)</code></li>
+         <li><code>skip_ssl_verification (optional)</code></li>
       </ul>
     </td>
   </tr>


### PR DESCRIPTION
- correctly list optional properties

[#/#168438481] Tile/Service authors should be able to define an install time verifier to run a HTTP/s request

Signed-off-by: Andy Brown <anbrown@pivotal.io>