### PR TITLE
Document new allow_encrypted_key constraint for RSA cert type

### DIFF
--- a/tile-reference/property-blueprints/_rsa-cert-credentials.html.erb
+++ b/tile-reference/property-blueprints/_rsa-cert-credentials.html.erb
@@ -15,6 +15,18 @@
               field of the cert.  The full list of domains will be the value of the Alternative Names field of the cert.
               See below for an example.
               DESC
+        },
+        {
+            name: 'constraints',
+            description: <<~DESC,
+              Constrains which RSA certificates are considered valid. See the below table for all supported constraint types.
+              DESC
+        }
+    ],
+    constraints: [
+        {
+            name: 'allow_encrypted_key',
+            description: 'Allows an encrypted private key to be used for <code>private_key_pem</code>. Defaults to <code>false</code>'
         }
     ],
     additional_accessors: [
@@ -32,7 +44,7 @@
       },
       {
         name: 'public_key_pem',
-        description: 'Returns a string'
+        description: 'Returns a string. Note: this accessor cannot be used when the <code>allow_encrypted_key</code> constraint is set to <code>true</code>.'
       }
     ],
     examples: [
@@ -49,6 +61,8 @@
               type: rsa_cert_credentials
               configurable: true
               optional: true
+              constraints:
+                allow_encrypted_key: true
             # This is not configurable by the operator and is auto-generated
             - name: example_non_configurable_rsa_cert_credentials
               type: rsa_cert_credentials


### PR DESCRIPTION
Ops Manager 2.5.25 now supports a new constraint type for `rsa-cert-credentials` property types. The new `allow_encrypted_key` constraint allows tile developers to allow encrypted private keys for these properties.

These docs will eventually need to be merged forward to 2.6 and beyond, but the feature is currently only available on 2.5.  Let us know if you have any questions / concerns!

Signed-off-by: Kenneth Lakin <klakin@pivotal.io>