### PR TITLE
Document using multiple LDAP URLs with verifier + property blueprint

### DIFF
--- a/property-template-references.html.md.erb
+++ b/property-template-references.html.md.erb
@@ -638,7 +638,7 @@ The following table lists the available install-time verifiers:
         <code>Verifiers::LDAPBindVerifier</code>
     </td>
     <td>
-      the specified LDAP server exists and that the provided credentials are valid.
+      the specified LDAP server exists and that the provided credentials are valid. Multiple LDAP servers may be verified if the <code>url</code> property is a space-separated list of server URLs.
     <td>
       <ul>
         <li><code>url</code></li>

--- a/tile-reference/property-blueprints/_ldap-url.html.erb
+++ b/tile-reference/property-blueprints/_ldap-url.html.erb
@@ -1,5 +1,5 @@
 <%= partial 'tile-reference/property-blueprint', locals: {
-    description: 'Ensures the inputted string matches a URL of the LDAP protocol.',
+    description: 'Ensures the inputted string matches a URL of the LDAP protocol, or a space-separated list of LDAP protocol URLs.',
     credential: false,
     auto_generatable: false,
     operator_configurable: true,


### PR DESCRIPTION
The `ldap_url` property blueprint has previously allowed multiple LDAP
URLs, but it was not documented. The LDAPBindVerifier now also accepts
a space-separate list of LDAP URLs.

Signed-off-by: Kenneth Lakin <klakin@pivotal.io>