### PR TITLE
Document new director context property: `metrics_server_enabled`

### DIFF
--- a/property-template-references.html.md.erb
+++ b/property-template-references.html.md.erb
@@ -190,6 +190,7 @@ The table below describes the accessors you can use to retrieve information abou
 | `ca_public_key` | Provides the public key that is used to sign the BOSH Director VM. |
 | `hostname` | Provides the hostname for the BOSH Director VM. |
 | `tld` | Returns the string `bosh` as the top-level domain (TLD) of the BOSH Director. |
+| `metrics_server_enabled` | True if the `system-metrics-server` job is included. |
 | `bosh_metrics_forwarder_client_name` | Provides the BOSH Metrics Forwarder client name. |
 | `bosh_metrics_forwarder_client_secret` | Provides the BOSH Metrics Forwarder client secret. |
 | `dns_release_present` | Exposes the BOSH Director configuration for `disable_dns_release`. |


### PR DESCRIPTION
Returns true if the `system-metrics-server` job of the
`bosh-system-metrics-server` release is included in the BOSH director
manifest

[#172294555] metrics-server PR