### PR TITLE
Documents keys for the `requires_product_versions` param

### DIFF
--- a/property-template-references.html.md.erb
+++ b/property-template-references.html.md.erb
@@ -442,6 +442,13 @@ A list of tile dependencies. If the required tile is not present in the <%= vars
 
 Supported restriction operators are `=`, `!=`, `>`, `<`, `>=`, `<=`, and `~>`.
 
+The following keys are supported:
+- `name`: The name of the tile required by your tile. This is a required key.
+- `version`: The version range required by your tile. This is a required key.
+- `optional`: Whether or not this dependency is optional. This is an optional key which defaults to *false*.
+
+<p class="note warning"><strong>Warning:</strong> The <code>optional</code> key was introduced in Ops Manager 2.8. It will be ignored in earlier versions, causing your declared dependency to be non-optional.</p>
+
 For example:
 
 ```


### PR DESCRIPTION
We explicitly describe the name and function of each key supported by
`requires_product_version`, rather than relying on the reader to notice
the keys provided in the example.

Signed-off-by: Ming Xiao <mxiao@pivotal.io>