### PR TITLE
Fix typo in property-template docs

### DIFF
--- a/property-template-references.html.md.erb
+++ b/property-template-references.html.md.erb
@@ -1398,7 +1398,7 @@ Alternatively, a property with `configurable: false` gets a value auto-generated
 Properties with `configurable` set to `false`:
 
 * Cannot be edited by the operator.
-* Do show up in forms, even if added under `form_types`.
+* Do not show up in forms, even if added under `form_types`.
 * Get auto-generated values filled in by Ops Manager if that specific type of property supports auto-generation of values.
 
 ### <a id='named-manifest'></a> named_manifest for Selector and Collection Type Properties


### PR DESCRIPTION
When a field is set to `configurable: false`, it hides the field in the UI, despite this statement to the contrary.