### PR TITLE
Remove redundant gorouter arch doc

### DIFF
--- a/tile-generator.html.md.erb
+++ b/tile-generator.html.md.erb
@@ -511,10 +511,10 @@ This file must be a `.tgz`.
       - "custom_variable_name=((.properties.customer_name.value))"
 ```
 
-To expose a container via
-[gorouter](https://docs.cloudfoundry.org/concepts/architecture/router.html),
+To expose a container via the
+[<%= vars.app_runtime_abbr %> Routing Architecture](https://docs.cloudfoundry.org/concepts/cf-routing-architecture.html),
 for example, one of the Docker containers hosts an admin webapp interface,
-use `routes` to choose a port and prefix. The external URL
+use the [`routes` property of the apps manifest](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#routes) to choose a port and prefix. The external URL
 is `[prefix]-[package.name].[system-domain]`.
 In this case, the URL is `https://admin-docker-bosh3.sys.example.com`, where `sys.example.com` is the <%= vars.app_runtime_abbr %> system domain.
 `routes` is a list, so multiple containers can be exposed.


### PR DESCRIPTION
## The Change
tl;dr: The information contained on that page was represented elsewhere and the page no longer needs to exist.

- the home for the majority of this content is in:
  - `docs-cloudfoundry-concepts/cf-routing-architecture.html`
  - `docs-cf-admin/troubleshooting-router-error-responses.html`

- Removes the following file and all links to file: `docs-cloudfoundry-concepts/architecture/router.html(.md.erb)`
- change link destinations to a more appropriate page
  - usually `docs-cloudfoundry-concepts/cf-routing-architecture.html`
- reorganize the flow of `docs-cloudfoundry-concepts/cf-routing-architecture.html`

PivotalTracker: [#174579096](https://www.pivotaltracker.com/story/show/174579096)

## Backports
Please backport these changes to TAS 2.7.

## Related PRs
- cloudfoundry/docs-cloudfoundry-concepts/pull/148
- cloudfoundry/docs-cf-admin/pull/193
- cloudfoundry/docs-book-cloudfoundry/pull/105
- pivotal-cf/docs-book-windows/pull/4
- pivotal-cf/docs-operating-pas/pull/40
- pivotal-cf/docs-partials/pull/29
- pivotal-cf/docs-pcf-windows/pull/73
- cloudfoundry/docs-routing/pull/3
- pivotal-cf/docs-tiledev/pull/106