### PR TITLE
Document optional `endpoint` property for BlobstoreVerifier

### DIFF
--- a/property-template-references.html.md.erb
+++ b/property-template-references.html.md.erb
@@ -549,6 +549,7 @@ The following table lists the available install-time verifiers:
         <li><code>secret_access_key</code></li>
         <li><code>signature_version</code></li>
         <li>(Optional) <code>endpoint</code></li>
+        <li>(Optional) <code>use_path_style</code></li>
       </ul>
     </td>
   </tr>

--- a/property-template-references.html.md.erb
+++ b/property-template-references.html.md.erb
@@ -548,6 +548,7 @@ The following table lists the available install-time verifiers:
         <li><code>bucket_name</code></li>
         <li><code>secret_access_key</code></li>
         <li><code>signature_version</code></li>
+        <li>(Optional) <code>endpoint</code></li>
       </ul>
     </td>
   </tr>


### PR DESCRIPTION
The `endpoint` field has been an optional property for the BlobstoreVerifier within Ops Manager for a long time. We should document it for 2.7 through 2.10