### PR TITLE
Update description for rsa_cert_credentials

### DIFF
--- a/tile-reference/property-blueprints/_rsa-cert-credentials.html.erb
+++ b/tile-reference/property-blueprints/_rsa-cert-credentials.html.erb
@@ -1,5 +1,5 @@
 <%= partial 'tile-reference/property-blueprint', locals: {
-    description: 'This holds SSL certificate generated from root CA',
+    description: 'This holds SSL certificate generated from root CA. The certificate is generated using the default duration of 730 days (2 years). If a minimum duration is provided in the BOSH Director and it is greater than the default duration, the certificate is generated using the minimum duration.',
     credential: true,
     auto_generatable: true,
     operator_configurable: true,


### PR DESCRIPTION
Please merge this after a new patch for 2.10 Ops Manager is released that contains Minimum Certificate Duration feature.

See also: https://github.com/pivotal-cf/docs-ops-manager/pull/189


Authored-by: Preethi Varambally <pvarambally@pivotal.io>
Authored-by: Brian Upton <bupton@vmware.com>