### PR TITLE
Fixes fields on the Blobstore Verifier.

### DIFF
--- a/property-template-references.html.md.erb
+++ b/property-template-references.html.md.erb
@@ -587,6 +587,7 @@ The following table lists the available install-time verifiers:
         <li>(Optional) <code>use_path_style</code></li>
         <li>(Optional) <code>endpoint</code></li>
         <li>(Optional) <code>use_path_style</code></li>
+        <li>(Optional, only available after Metadata version 2.10.1, shipped on Ops Manager v2.10.21) <code>ca_cert</code></li>
       </ul>
     </td>
   </tr>
@@ -738,6 +739,7 @@ install_time_verifiers:
     secret_access_key: .properties.system_blobstore.external.secret_key
     signature_version: .properties.system_blobstore.external.signature_version
     use_path_style: .properties.system_blobstore.external.use_path_style # Optional. Defaults to false
+    ca_cert: .properties.system_blobstore.external.ca_cert
 - ignorable: true
   name: Verifiers::MysqlDatabaseVerifier
   properties:


### PR DESCRIPTION
Since Ops manager 2.10.21 the BlobstoreVerifier is able to receive the
field `ca_cert` that enables the verifier to use a custom ca with a blobstore
that is using a self crafted cert. This field was undocumented until
now.

[#182334052]