### PR TITLE
Document vSphere verifier field in 3.0.2

### DIFF
--- a/property-template-references.html.md.erb
+++ b/property-template-references.html.md.erb
@@ -726,6 +726,7 @@ The following table lists the available install-time verifiers:
         <li><code>vcenter_credentials</code></li>
         <li><code>datacenter</code></li>
         <li><code>datastore_pattern</code></li>
+        <li>(Optional) <code>vcenter_ca_certificate</code></li>
       </ul>
     </td>
   </tr>


### PR DESCRIPTION
~Do not merge yet - feature hasn't been released~ This has been released and is ready to merge.

* Documents the new vcenter_ca_certificate field in the vSphere verifier