### PR TITLE
Clarify nesting of complex property types (2.10)

### DIFF
--- a/property-template-references.html.md.erb
+++ b/property-template-references.html.md.erb
@@ -242,7 +242,7 @@ Selectors appear as follows:
 
 The selector and collections inputs are referenced by their selector and collection property blueprints.
 
-Most properties are simple values, for example,  strings, integers, URL addresses, or IP addresses. Selectors and collections are more complicated than simple properties because they contain manifest snippets, which are further referenced in other manifest snippets. Selectors and collections can exist alone, or nest within each other or within different parts of the manifest.
+Most properties are simple values, for example,  strings, integers, URL addresses, or IP addresses. Selectors and collections are more complicated than simple properties because they contain manifest snippets, which are further referenced in other manifest snippets. Selector and collection properties can only exist as top-level properties; you cannot nest selector properties inside of collections properties, vice-versa, or nest them inside themselves (e.g. a selector nested inside of a selector).
 
 ## <a id='top-level'></a> Top-Level Properties
 ### <a id="non-configurable-certs"></a> Non-configurable certificates are invalid within a selector

--- a/property-template-references.html.md.erb
+++ b/property-template-references.html.md.erb
@@ -242,9 +242,10 @@ Selectors appear as follows:
 
 The selector and collections inputs are referenced by their selector and collection property blueprints.
 
-Most properties are simple values, for example,  strings, integers, URL addresses, or IP addresses. Selectors and collections are more complicated than simple properties because they contain manifest snippets, which are further referenced in other manifest snippets. Selector and collection properties can only exist as top-level properties; you cannot nest selector properties inside of collections properties, vice-versa, or nest them inside themselves (e.g. a selector nested inside of a selector).
+Most properties are simple values such as strings, integers, URL addresses, or IP addresses. Selectors and collections are more complicated than simple properties, because they contain manifest snippets, which are further referenced in other manifest snippets. Selector and collection properties can only exist as top-level properties. You cannot nest selector properties inside of collection properties, nest collection properties inside of selector properties, or nest these properties inside themselves (for example, nesting a selector inside of a selector).
 
 ## <a id='top-level'></a> Top-Level Properties
+
 ### <a id="non-configurable-certs"></a> Non-configurable certificates are invalid within a selector
 
 The  `rsa_cert_credentials` property with `configurable: false` is invalid within a `selector` property.

--- a/tile-reference/property-blueprints/_collection.html.erb
+++ b/tile-reference/property-blueprints/_collection.html.erb
@@ -1,5 +1,7 @@
 This holds multiple records of a group of custom defined properties.
 
+You cannot nest selector properties or other collection properties inside of a collection.
+
 <table class="nice">
   <tr>
     <td>credential</td>

--- a/tile-reference/property-blueprints/_selector.html.erb
+++ b/tile-reference/property-blueprints/_selector.html.erb
@@ -10,6 +10,8 @@ conditionally adding manifest snippets. A manifest snippet should be present wit
 and can be used to create a simple kind of branching logic in manifest generation.
 Only one of these sets is evaluated and inserted into the job’s manifest.
 
+You cannot nest collection properties or other selector properties inside of a selector.
+
 <table class="nice">
   <tr>
     <td>credential</td>


### PR DESCRIPTION
The docs suggested in one spot that it was possible to nest selectors inside of collections, which is not accurate and is contradicted in other places within the docs. This change attempts to make it clear that they cannot be nested within each other.