### PR TITLE
Update deprecated properties in 3.0

### DIFF
--- a/property-template-references.html.md.erb
+++ b/property-template-references.html.md.erb
@@ -196,13 +196,10 @@ The following table describes the accessors you can use to retrieve information 
 | `ca_public_key` | Provides the public key that is used to sign the BOSH Director VM |
 | `hostname` | Provides the hostname for the BOSH Director VM |
 | `tld` | Returns the string `bosh` as the top-level domain (TLD) of the BOSH Director |
-| `metrics_server_enabled` | Returns `true` if the `system-metrics-server` job is included in the manifest.<br>For information about the job, see <a href="https://bosh.io/jobs/system-metrics-server?source=github.com/cloudfoundry/bosh-system-metrics-server-release">system-metrics-server job</a> in the BOSH documentation. |
-| `bosh_metrics_forwarder_client_name` | Provides the BOSH Metrics Forwarder client name |
-| `bosh_metrics_forwarder_client_secret` | Provides the BOSH Metrics Forwarder client secret |
-| `metrics_server_enabled` | Exposes whether the `system-metrics-server` job of the `bosh-system-metrics-server` release is included in the BOSH Director. |
 | `system_metrics_runtime_enabled` | Exposes whether the `ops_manager_system_metrics_runtime` is added to the BOSH Director. |
-| `dns_release_present` | Exposes the BOSH Director configuration for `disable_dns_release` |
-| `metrics_server_enabled` | Exposes the BOSH Director configuration for `metrics_server_enabled` |
+| `metrics_server_enabled` | Deprecated. Always returns `false` |
+| `bosh_metrics_forwarder_client_name` | Deprecated. Always returns a constant, non-credential value |
+| `bosh_metrics_forwarder_client_secret` | Deprecated. Always returns a constant, non-credential value |
 
 #### <a id='runtime'></a> $runtime
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -34,6 +34,8 @@ Known issues in this release that can affect tile development for partners:
 
 ### <a id="removed-accessors"></a> Removed accessors
 
+The `metrics_server_enabled` accessor has been deprecated due to the removal of the BOSH System Metrics Server release in <%= vars.ops_manager %> 3.0. The accessor now always returns `false`.
+
 The following accessors have been removed. If you reference them, invalid data is returned, but does not
 cause an error:
 


### PR DESCRIPTION
Also removes references to the $director.dns_release_present property, which was deprecated in prior versions of Ops Manager.