### PR TITLE
Fix additional_stemcells_criteria example 3.0

### DIFF
--- a/tile-reference/property-blueprints/_stemcell-selector.html.erb
+++ b/tile-reference/property-blueprints/_stemcell-selector.html.erb
@@ -80,8 +80,8 @@ stemcell_criteria:
   os: ubuntu-xenial
   version: 1.0.0
 additional_stemcells_criteria:
-  os: windows2016
-  version: 1.0.0
+  - os: windows2019
+    version: 2019.73
 
 property_blueprints:
   - name: example_stemcell_selector


### PR DESCRIPTION
The additional_stemcells_criteria field is an array of hashes, but the documentation for the stemcell selector datatype is incorrect.

This updates this doc to the correct datatype and also updates to an example that is more realistic.

[#187467092] Correct additional_stemcells_criteria example in stemcell_selector property in Tile Dev Docs