### PR TITLE
Remove mentions of image support in markdown (2.10)

### DIFF
--- a/property-template-references.html.md.erb
+++ b/property-template-references.html.md.erb
@@ -831,8 +831,6 @@ form_types:
     markdown: |
       ## I am markdown, hear me _roar_.
 
-      ![Alt text](http://placekitten.com/g/400/200)
-
       Things to do:
 
       1. Learn [markdown](https://daringfireball.net/projects/markdown/).
@@ -935,7 +933,7 @@ The description of the form. Appears at the top of the form as a header.
 * **Format:** Markdown
 * **Type:** Optional
 
-Provide a block of markdown to display at the top of the form, including image support. Use this property to document the tile and provide explanations or references.
+Provide a block of markdown to display at the top of the form. Use this property to document the tile and provide explanations or references. External images are not supported.
 
 ### <a id='form-property-inputs'></a> property_inputs
 


### PR DESCRIPTION
[#183841684] Content Security policy blocks remote image in Example Product tile